### PR TITLE
Fix brew test-bot CI (Linux sandbox + style/audit)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@main
 
       - name: Pull bottles
         env:
@@ -26,7 +26,7 @@ jobs:
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@main
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,16 +9,22 @@ on:
 jobs:
   test-bot:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
+    env:
+      # The Linux sandbox needs a rootless `bwrap`, which isn't available
+      # on GitHub runners (unprivileged user namespaces are restricted), so
+      # `brew doctor` fails during `--only-setup`. Disable it. No-op on macOS.
+      HOMEBREW_NO_SANDBOX_LINUX: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -35,7 +41,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'

--- a/Formula/autosentry.rb
+++ b/Formula/autosentry.rb
@@ -23,8 +23,9 @@ class Autosentry < Formula
   license "Apache-2.0"
   head "https://github.com/ulmentflam/autosentry.git", branch: "main"
 
-  depends_on "python@3.13"
+  # Ordered build > normal to satisfy FormulaAudit/DependencyOrder.
   depends_on "rust" => :build # pydantic-core compiles from sdist via maturin/cargo
+  depends_on "python@3.13"
 
   resource "annotated-doc" do
     url "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz"
@@ -66,7 +67,7 @@ class Autosentry < Formula
     sha256 "edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
   end
 
-  resource "ruamel.yaml" do
+  resource "ruamel-yaml" do
     url "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz"
     sha256 "53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993"
   end

--- a/Formula/corpus-forge.rb
+++ b/Formula/corpus-forge.rb
@@ -15,7 +15,7 @@
 class CorpusForge < Formula
   include Language::Python::Virtualenv
 
-  desc "Chat with your data — forge a living, trainable corpus from notes, code, and chat history"
+  desc "Forge a living, trainable corpus from notes, code, and chat history"
   homepage "https://github.com/ulmentflam/corpus-forge"
   url "https://github.com/ulmentflam/corpus-forge/archive/refs/tags/v0.1.0b10.tar.gz"
   # Update this on each release. ``shasum -a 256 corpus-forge-<version>.tar.gz``
@@ -24,13 +24,15 @@ class CorpusForge < Formula
   head "https://github.com/ulmentflam/corpus-forge.git", branch: "main"
 
   depends_on "python@3.12"
-  depends_on "uv" => :recommended
 
-  # Optional runtime deps unlocked by the ``[ocr]`` and ``[whisper]``
-  # extras. Brew handles them as recommended depends_on so users can
-  # opt out (``--without-poppler``) on a per-formula basis.
-  depends_on "poppler" => :recommended
+  # Recommended deps, ordered alphabetically to satisfy
+  # FormulaAudit/DependencyOrder. ``ffmpeg``/``poppler`` are optional
+  # runtime deps unlocked by the ``[whisper]`` and ``[ocr]`` extras;
+  # ``uv`` backs the in-app ``update`` path. All are recommended so
+  # users can opt out (e.g. ``--without-poppler``).
   depends_on "ffmpeg" => :recommended
+  depends_on "poppler" => :recommended
+  depends_on "uv" => :recommended
 
   def install
     virtualenv_install_with_resources

--- a/Formula/k/key-gen.rb
+++ b/Formula/k/key-gen.rb
@@ -1,9 +1,10 @@
 class KeyGen < Formula
-  desc "key-gen is a CLI tool to generate keys for various blockchains"
+  desc "Generate keys for various blockchains"
   homepage "https://github.com/ulmentflam/key-gen"
-  license "GPLv3"
   url "https://github.com/ulmentflam/key-gen/releases/download/v0.0.2/key-gen-v0.0.2-darwin-arm64.tar.gz"
   sha256 "8881d1bca3adb274a4a1de09e98765a9d0113f84f8992b107ca5c01325bd5c0b"
+  license "GPL-3.0-or-later"
+
   def install
     bin.install "key-gen"
   end

--- a/Formula/k/key-gen.rb
+++ b/Formula/k/key-gen.rb
@@ -5,6 +5,12 @@ class KeyGen < Formula
   sha256 "8881d1bca3adb274a4a1de09e98765a9d0113f84f8992b107ca5c01325bd5c0b"
   license "GPL-3.0-or-later"
 
+  # Upstream ships a single darwin-arm64 release tarball, so restrict the
+  # formula to Apple Silicon macOS. test-bot skips it on other platforms.
+  # Ordered arch before macos to satisfy FormulaAudit/DependencyOrder.
+  depends_on arch: :arm64
+  depends_on :macos
+
   def install
     bin.install "key-gen"
   end

--- a/Formula/nightly.rb
+++ b/Formula/nightly.rb
@@ -21,9 +21,9 @@ class Nightly < Formula
   license "MIT"
   head "https://github.com/ulmentflam/nightly.git", branch: "main"
 
+  depends_on "git"
   depends_on "python@3.12"
   depends_on "uv"
-  depends_on "git"
 
   def install
     # Move the unpacked source into libexec, then materialize the venv


### PR DESCRIPTION
## Why CI was red

Every `brew test-bot` run had been failing — including the Renovate PRs, which is the tell that the break was in *setup*, not in any one formula. Two independent root causes:

### 1. Linux `--only-setup` failed in `brew doctor`
```
Bubblewrap is required to use the Linux sandbox but was not found.
```
Homebrew's Linux sandbox now requires a rootless `bwrap`, which GitHub runners don't provide (unprivileged user namespaces are restricted). With the default `fail-fast`, the Linux failure also canceled the macOS jobs.

**Fix:** set `HOMEBREW_NO_SANDBOX_LINUX=1` (the documented workaround; no-op on macOS) and `fail-fast: false` so each OS reports independently.

### 2. macOS `--only-tap-syntax` failed `brew style` + `brew audit`
- **autosentry** — order `rust` (build) before `python` (`FormulaAudit/DependencyOrder`); rename `resource "ruamel.yaml"` → `"ruamel-yaml"` to match the normalized PyPI name.
- **corpus-forge** — shorten `desc` to <80 chars; order recommended deps alphabetically (`ffmpeg`, `poppler`, `uv`).
- **nightly** — order deps alphabetically (`git`, `python`, `uv`).
- **key-gen** — capitalize `desc` and drop the formula-name prefix; move `url`/`sha256` before `license`; use SPDX `GPL-3.0-or-later`.

## Renovate / deprecations folded in
- `ubuntu-22.04` → `ubuntu-24.04` (#2)
- `actions/cache` v4 → v5 (#5)
- `actions/upload-artifact` v4 → v7 (#4)
- `Homebrew/actions/*@master` → `@main` in both workflows (the `@master` sync becomes a hard error at Homebrew 5.2.0)

Merging this makes #2, #4, and #5 redundant (Renovate will auto-close them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple Homebrew formulas: clarified descriptions, adjusted metadata and dependency declarations.
  * Updated CI workflows to use newer action branches/versions for improved compatibility.
  * Expanded test infrastructure to include a newer Linux runner and adjusted Linux-only setup behavior for more reliable test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ulmentflam/homebrew-tap/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->