### PR TITLE
ci: pin GitHub Action refs to immutable commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@main
+        uses: Homebrew/actions/git-user-config@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main
 
       - name: Pull bottles
         env:
@@ -26,7 +26,7 @@ jobs:
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@main
+        uses: Homebrew/actions/git-try-push@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main
 
       - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'


### PR DESCRIPTION
Addresses the review findings on `tests.yml` and `publish.yml`: replace mutable tag/branch action refs with immutable commit SHAs (supply-chain hardening — a moved tag/branch can swap in different code).

## Verification
All six findings verified as **still valid** against current `main` — every `uses:` line used a mutable ref (`@main` / `@v5` / `@v7`); none were already pinned. Nothing was skipped.

## Changes
| File | Action | Before | After |
|------|--------|--------|-------|
| tests.yml | `Homebrew/actions/setup-homebrew` | `@main` | `@6eaeff8` `# main` |
| tests.yml | `actions/cache` | `@v5` | `@27d5ce7` `# v5.0.5` |
| tests.yml | `actions/upload-artifact` | `@v7` | `@043fb46` `# v7.0.1` |
| publish.yml | `setup-homebrew` / `git-user-config` / `git-try-push` | `@main` | `@6eaeff8` `# main` |

All three `Homebrew/actions/*` live in one repo, so they share one SHA (`Homebrew/actions` `main` HEAD).

## Notes
- Trailing `# <version>`/`# main` comments let Renovate keep the SHAs current (no manual bumps).
- The `Homebrew/actions/*` SHAs equal today's `main` HEAD, so there's **no behavior change now** — this just freezes against silent force-moves; Renovate advances them. (Branch refs are the Homebrew tap convention, so this is the one trade-off: SHAs need Renovate/maintainer bumps to stay current with Homebrew's cadence.)
- Validated: both workflows parse as YAML; actionlint (run in the `--only-tap-syntax` step) accepts SHA pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions dependencies across CI/CD workflows to use specific commit SHAs instead of floating branch references or version tags. Changes impact setup, caching, and artifact upload mechanisms while preserving existing workflow functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ulmentflam/homebrew-tap/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->