### PR TITLE
autosentry: re-apply formula audit fixes reverted by v0.7.4 bump

### DIFF
--- a/Formula/autosentry.rb
+++ b/Formula/autosentry.rb
@@ -23,8 +23,9 @@ class Autosentry < Formula
   license "Apache-2.0"
   head "https://github.com/ulmentflam/autosentry.git", branch: "main"
 
-  depends_on "python@3.13"
+  # Ordered build > normal to satisfy FormulaAudit/DependencyOrder.
   depends_on "rust" => :build # pydantic-core compiles from sdist via maturin/cargo
+  depends_on "python@3.13"
 
   resource "annotated-doc" do
     url "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz"
@@ -66,7 +67,7 @@ class Autosentry < Formula
     sha256 "edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
   end
 
-  resource "ruamel.yaml" do
+  resource "ruamel-yaml" do
     url "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz"
     sha256 "53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993"
   end


### PR DESCRIPTION
## What happened
`main`'s `brew test-bot --only-tap-syntax` is **red again**. The `autosentry v0.7.4` release bump (`c22712e`) regenerated `Formula/autosentry.rb` from autosentry's source template — which still carried the pre-fix formula — reverting the fixes from #6:

```
FormulaAudit/DependencyOrder: `dependency "rust"` should be before `dependency "python@3.13"`
Stable/HEAD resource "ruamel.yaml": `resource` name should be 'ruamel-yaml'
```

## This PR
Re-applies both fixes to the tap formula so `main` goes green again:
- `rust` (`:build`) ordered before `python@3.13`
- `resource "ruamel.yaml"` → `"ruamel-yaml"`

## Stops it recurring
The root cause is the source template. Fixed there in **ulmentflam/autosentry#3** (template + `gen_resources.py` now emit audit-correct output). Once that merges, future `brew-bump` releases won't revert this again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build dependency ordering and configuration clarity to enhance installation reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ulmentflam/homebrew-tap/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->