### PR TITLE
ci: drop Intel macos-13, add latest macOS (macos-26)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14]
+        # macOS entries are Apple Silicon (arm64): corpus-forge and key-gen
+        # ship no x86_64-macOS wheels/binaries, so Intel macOS is unsupported.
+        # macos-26 is the latest (Tahoe); macos-14 keeps older-arm64 coverage.
+        os: [ubuntu-24.04, macos-14, macos-26]
     runs-on: ${{ matrix.os }}
     env:
       # The Linux sandbox needs a rootless `bwrap`, which isn't available


### PR DESCRIPTION
Updates the `brew test-bot` matrix: drop Intel `macos-13`, add the latest macOS runner `macos-26` (Tahoe), keep `macos-14`.

```diff
- os: [ubuntu-24.04, macos-13, macos-14]
+ os: [ubuntu-24.04, macos-14, macos-26]
```

### Why
- **`macos-13` (Intel) added no coverage.** corpus-forge and key-gen ship no x86_64-macOS wheels/binaries and are skipped on Intel; only autosentry built there. Our macOS support is Apple-Silicon-only by design.
- **`macos-26` is the newest runner** (Tahoe, GA since Feb 2026) and its **base label is Apple Silicon (arm64)** — so the arm64-restricted formulae actually build/test on it (the Intel variant is the separate `macos-26-intel` label). Free for public repos.
- **`macos-14` kept** for older-arm64 coverage.

Renovate (already configured, tracks runner versions) will bump `macos-26` as newer macOS runners land.

Sources: [macos-26 GA changelog](https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/), [runner-images macos-26-arm64](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test matrix to include macOS 26 while discontinuing macOS 13, maintaining coverage on macOS 14 and Ubuntu 24.04.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ulmentflam/homebrew-tap/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->